### PR TITLE
Fix: Pin OpenTelemetry dependencies to resolve ImportError crash loop

### DIFF
--- a/Payload_Type/sage/requirements.txt
+++ b/Payload_Type/sage/requirements.txt
@@ -17,5 +17,6 @@ mythic-container==0.6.12
 # There's a bug with aiosqlite 0.22.0 in langraph
 # https://github.com/langchain-ai/langgraph/issues/6583
 aiosqlite==0.21.0
-arize-phoenix
-opentelemetry-instrumentation-langchain
+arize-phoenix==13.3.0
+opentelemetry-instrumentation-langchain==0.52.4
+opentelemetry-semantic-conventions-ai==0.4.13


### PR DESCRIPTION
## Summary

- Pins `arize-phoenix==13.3.0`, `opentelemetry-instrumentation-langchain==0.52.4`, and `opentelemetry-semantic-conventions-ai==0.4.13` in `requirements.txt`
- Fixes crash loop caused by `opentelemetry-instrumentation-langchain==0.52.5` importing `GenAICustomOperationName` which doesn't exist in `opentelemetry-semantic-conventions-ai<0.4.15`

## Problem

The unpinned `opentelemetry-instrumentation-langchain` resolves to `0.52.5` (released 2026-02-23), which tries to import `GenAICustomOperationName` from `opentelemetry.semconv_ai`. That symbol was only added in `opentelemetry-semantic-conventions-ai==0.4.15` (released 2026-03-02), but `0.52.5` declares a dependency of `>=0.4.13,<0.5.0` — so pip installs `0.4.13` which lacks the symbol. This causes an immediate `ImportError` crash loop on container start.

## Fix

Pin to the last known-good versions from 2026-02-19/20:

| Package | Version | Released |
|---|---|---|
| `arize-phoenix` | 13.3.0 | 2026-02-20 |
| `opentelemetry-instrumentation-langchain` | 0.52.4 | 2026-02-19 |
| `opentelemetry-semantic-conventions-ai` | 0.4.13 | 2025-08-22 |

## Testing

1. `sudo ./mythic-cli build sage` — builds successfully
2. `sudo ./mythic-cli start sage` — container starts without crash loop
3. `sudo ./mythic-cli logs sage` — no ImportError
